### PR TITLE
Ability to render columns using the entire object

### DIFF
--- a/src/sortable-table-body.js
+++ b/src/sortable-table-body.js
@@ -7,6 +7,9 @@ class SortableTableRow extends Component {
       if ( item.render ) {
         value = item.render(value)
       }
+      if ( item.renderWithData ) {
+        value = item.renderWithData(this.props.data)
+      }
       return (
         <td
           key={index}


### PR DESCRIPTION
This extension allows users to create links in a column using data that isn't present in the immediate column. The user can have a user.alias column that links to the profile page using the user.id, e.g. `renderWithData: (user) => { return <a href={'users/' + user.id}>{user.alias}</a> }`